### PR TITLE
Custom output messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,30 @@ jobs:
 
 Note that the `GITHUB_TOKEN` secret is automatically available, so you don't need to do anything else about that.
 
-By default, it will run `yarn test-coverage`. 
-Either you add something like this: `"test-coverage": "COVERAGE=true ember test"` to your package.json file, 
-or you can specify a custom test command:
 
-```yaml
-- uses: mydea/ember-cli-code-coverage-action@v1
-  with:
-    repo-token: "${{ secrets.GITHUB_TOKEN }}"
-    test-command: "yarn my-test-command"
-```
+## Setting up
 
-You can also specify a custom `coverage-file` (defaults to `./coverage/coverage-summary.json`), 
-If ember app located not in the root of a repo you should also specify  `working-directory` option.
+`repo-token` **required**
+Token to post statuses and comments on yore repo. Note that the `GITHUB_TOKEN` secret is automatically available, so you don't need to do anything else about that.
 
-and a `coverage-indicator`, which defaults to `statement` (which defines which type of coverage will be used).
+
+`test-command` *optional*
+Default: `yarn test-coverage`
+The command to run your tests.
+Either you add something like this: `"test-coverage": "COVERAGE=true ember test"` to your package.json file, or you can specify a custom test command.
+
+`coverage-file` *optional*
+Default: `./coverage/coverage-summary.json`
+The location of coverage summary.json file.
+
+`coverage-indicator` *indicator*
+Default: `statements`
+The coverage type to use. One of: `statements`, `lines`, `functions`, `branches`.
+
+`working-directory` *directory*
+Default: `./`
+Ember app directory.
+
+`message` *optional*
+Default: `Test coverage: **{testCoverage}%**`
+Message title that will be used when posting status on PR comments section.

--- a/README.md
+++ b/README.md
@@ -40,4 +40,6 @@ or you can specify a custom test command:
 ```
 
 You can also specify a custom `coverage-file` (defaults to `./coverage/coverage-summary.json`), 
+If ember app located not in the root of a repo you should also specify  `working-directory` option.
+
 and a `coverage-indicator`, which defaults to `statement` (which defines which type of coverage will be used).

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   coverage-indicator:
     descirption: 'The coverage type to use. One of: statements, lines, functions, branches'
     default: 'statements'
+  working-directory:
+    descirption: 'Ember app directory'
+    default: './'
 runs:
   using: 'node12'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -14,13 +14,13 @@ inputs:
     description: 'The location of coverage summary.json file'
     default: './coverage/coverage-summary.json'
   coverage-indicator:
-    descirption: 'The coverage type to use. One of: statements, lines, functions, branches'
+    description: 'The coverage type to use. One of: statements, lines, functions, branches'
     default: 'statements'
   working-directory:
-    descirption: 'Ember app directory'
+    description: 'Ember app directory'
     default: './'
   message:
-    descirption: 'Comment message title that will be posted on PR'
+    description: 'Comment message title that will be posted on PR'
     default: 'Test coverage: **{testCoverage}%**'
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   working-directory:
     descirption: 'Ember app directory'
     default: './'
+  message:
+    descirption: 'Comment message title that will be posted on PR'
+    default: 'Test coverage: **{testCoverage}%**'
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ ${body}`);
 }
 
 async function getTestCoverage({ testCommand, coverageFilePath, coverageIndicator, workingDirectory }) {
-  await exec(testCommand,{cwd:workingDirectory});
+  await exec(testCommand,[],{cwd:workingDirectory});
 
   let coverageFile = fs.readFileSync(coverageFilePath, 'utf-8');
   let coverageSummary = JSON.parse(coverageFile);

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ async function run() {
     let coverageFilePath = getInput('coverage-file', { required: true });
     let coverageIndicator = getInput('coverage-indicator', { required: true });
     let workingDirectory = getInput('working-directory', { required: true });
-    let messageFormat = getInput('message', { required: false });
+    let messageFormat = getInput('message', { required: true });
     
 
     octokit = new GitHub(myToken);

--- a/index.js
+++ b/index.js
@@ -13,18 +13,20 @@ async function run() {
     let testCommand = getInput('test-command', { required: true });
     let coverageFilePath = getInput('coverage-file', { required: true });
     let coverageIndicator = getInput('coverage-indicator', { required: true });
+    let workingDirectory = getInput('working-directory', { required: true });
+    
 
     octokit = new GitHub(myToken);
     let pullRequest = await getPullRequest();
 
-    let testCoverage = await getTestCoverage({ testCommand, coverageFilePath, coverageIndicator });
+    let testCoverage = await getTestCoverage({ testCommand, coverageFilePath, coverageIndicator, workingDirectory });
 
     await exec(`git checkout ${pullRequest.base.sha}`);
 
     // This could fail, e.g. if no test coverage existed before
     let testCoverageBefore;
     try {
-      testCoverageBefore = await getTestCoverage({testCommand, coverageFilePath, coverageIndicator});
+      testCoverageBefore = await getTestCoverage({testCommand, coverageFilePath, coverageIndicator, workingDirectory});
     } catch (error) {
       testCoverageBefore = 0;
     }
@@ -52,8 +54,8 @@ ${body}`);
   }
 }
 
-async function getTestCoverage({ testCommand, coverageFilePath, coverageIndicator }) {
-  await exec(testCommand);
+async function getTestCoverage({ testCommand, coverageFilePath, coverageIndicator, workingDirectory }) {
+  await exec(testCommand,{cwd:workingDirectory});
 
   let coverageFile = fs.readFileSync(coverageFilePath, 'utf-8');
   let coverageSummary = JSON.parse(coverageFile);

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ async function run() {
     let coverageFilePath = getInput('coverage-file', { required: true });
     let coverageIndicator = getInput('coverage-indicator', { required: true });
     let workingDirectory = getInput('working-directory', { required: true });
+    let messageFormat = getInput('message', { required: false });
     
 
     octokit = new GitHub(myToken);
@@ -43,7 +44,7 @@ Previous test coverage: ${testCoverageBefore}%
     
     `);
 
-    let body = buildOutput({ testCoverage, testCoverageBefore });
+    let body = buildOutput(messageFormat,{ testCoverage, testCoverageBefore });
 
     try {
       await octokit.issues.createComment({

--- a/lib/build-output.js
+++ b/lib/build-output.js
@@ -1,12 +1,10 @@
 const DEFAULT_FORMAT = 'Test coverage: **{testCoverage}%**';
 
-
-
 function buildOutput(mainMessageTemplate = DEFAULT_FORMAT,{testCoverage, testCoverageBefore}) {
     let diff = testCoverage - testCoverageBefore;
 
     let outputParts = [
-        processTemplate(mainMessageTemplate,{testCoverage})
+        processTemplate(mainMessageTemplate,{testCoverage:formatNumber(testCoverage)}),
     ];
 
     if(!testCoverageBefore) {
@@ -34,7 +32,7 @@ function formatNumber(num) {
 function processTemplate(template,dict){
     let result = template;
     Object.entries(dict).forEach(([key,value])=>{
-        const regexp = `{\s*${key}\s*}`
+        const regexp = `{\\s*${key}\\s*}`
         template.replace(new RegExp(regexp,'gmi'),value)
     })
     return result;

--- a/lib/build-output.js
+++ b/lib/build-output.js
@@ -1,6 +1,4 @@
-const DEFAULT_FORMAT = 'Test coverage: **{testCoverage}%**';
-
-function buildOutput(mainMessageTemplate = DEFAULT_FORMAT,{testCoverage, testCoverageBefore}) {
+function buildOutput(mainMessageTemplate,{testCoverage, testCoverageBefore}) {
     let diff = testCoverage - testCoverageBefore;
 
     let outputParts = [
@@ -33,7 +31,7 @@ function processTemplate(template,dict){
     let result = template;
     Object.entries(dict).forEach(([key,value])=>{
         const regexp = `{\\s*${key}\\s*}`
-        template.replace(new RegExp(regexp,'gmi'),value)
+        result = result.replace(new RegExp(regexp,'gmi'),value)
     })
     return result;
 }

--- a/lib/build-output.js
+++ b/lib/build-output.js
@@ -1,7 +1,13 @@
-function buildOutput({testCoverage, testCoverageBefore}) {
+const DEFAULT_FORMAT = 'Test coverage: **{testCoverage}%**';
+
+
+
+function buildOutput(mainMessageTemplate = DEFAULT_FORMAT,{testCoverage, testCoverageBefore}) {
     let diff = testCoverage - testCoverageBefore;
 
-    let outputParts = [`Test coverage: **${formatNumber(testCoverage)}%**`];
+    let outputParts = [
+        processTemplate(mainMessageTemplate,{testCoverage})
+    ];
 
     if(!testCoverageBefore) {
         outputParts.push('\n\n:rotating_light: No before coverage could be loaded');
@@ -23,4 +29,13 @@ module.exports = {buildOutput};
 
 function formatNumber(num) {
     return num.toFixed(2) * 1;
+}
+
+function processTemplate(template,dict){
+    let result = template;
+    Object.entries(dict).forEach(([key,value])=>{
+        const regexp = `{\s*${key}\s*}`
+        template.replace(new RegExp(regexp,'gmi'),value)
+    })
+    return result;
 }


### PR DESCRIPTION
Hi @mydea !

Using this action in a monorepo. It would be great to have customized output messaged since we might have multiple test-coverage actions.

Decided to discuss with you before implementing this idea.

Suggested format:

```yaml
  …
  with: 
    repo-token: "${{ secrets.GITHUB_TOKEN }}"
    test-command: "yarn my-test-command"
    output:
      header: Admin UI test coverage: **{{coverage}}%**
      no-before: :rotating_light: No before coverage could be loaded
      increased: :tada: Increased by +{{coverage}}% (was {{coverageBefore}}%)
      decreased: : n:rotating_light: Decreased by +{{coverage}}% (was {{coverageBefore}}%)
      no-change: :man_shrugging: Did not change
```