### PR TITLE
upd(deps): upgrade checkout gh action

### DIFF
--- a/.github/workflows/ember-cli-code-coverage.yml
+++ b/.github/workflows/ember-cli-code-coverage.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
       - name: ember-cli-code-coverage-action
         uses: ./ # Uses an action in the root directory
         id: ember-cli-code-coverage-action

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - uses: mydea/actions-ember-testing@v1
     - name: Install dependencies
       run: yarn install


### PR DESCRIPTION
This upgrades the Github checkout action used and adds the `fetchDepth` parameter to avoid `reference is not a tree` errors  I encountered when updating the action version before.